### PR TITLE
fix: links that contain a fragment (#) but point externally to anothe…

### DIFF
--- a/_src/scripts/lib-franklin-api.js
+++ b/_src/scripts/lib-franklin-api.js
@@ -174,16 +174,27 @@ export async function loadComponent(offer, block, options, selector)  {
     updateLinkSources(shadowRoot, `${origin}${offerFolder}/`);
     await js.default(shadowRoot.querySelector('.section'), {...options, metadata: parseMetadata(shadowRoot)});
     decorateIcons(shadowRoot);
+
+    // Get the current page path without the hash part and query
+    const currentPagePath = window.location.protocol + '//' + window.location.host + window.location.pathname;
     // get all the links that pointing within the page with a hash
     shadowRoot.querySelectorAll('a[href*="#"]').forEach(link => {
-      link.addEventListener('click', (event) => {
-        event.preventDefault();
-
-        let linkAnchor = link.getAttribute('href');
-        linkAnchor = '#' + linkAnchor.split('#')[1];
-        const target = document.querySelector(linkAnchor);
-        target.scrollIntoView({ behavior: 'smooth' });
-      });
+      let linkAnchor = link.getAttribute('href');
+      try {
+        const parsedLinkAnchor = new URL(linkAnchor, currentPagePath);
+        const linkAnchorPath = parsedLinkAnchor.protocol + '//' + parsedLinkAnchor.host + parsedLinkAnchor.pathname;
+        if (currentPagePath === linkAnchorPath) {
+          link.addEventListener('click', (event) => {
+            event.preventDefault();
+  
+            linkAnchor = '#' + linkAnchor.split('#')[1];
+            const target = document.querySelector(linkAnchor);
+            target.scrollIntoView({ behavior: 'smooth' });
+          });
+        }
+      } catch (e) {
+        return;
+      }
     });
   }
 


### PR DESCRIPTION
…r page

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/zh-hk/
- After: https://anchors--www-websites--bitdefender.hlx.page/zh-hk/
