### PR TITLE
DEX-20169

### DIFF
--- a/_src/scripts/utils/utils.js
+++ b/_src/scripts/utils/utils.js
@@ -351,8 +351,8 @@ export function formatPrice(price, currency, region = null, locale = null) {
   if (!price) {
     return null;
   }
-  const loc = region ? IANA_BY_REGION_MAP.get(Number(region))?.locale || 'en-US' : locale;
-  return new Intl.NumberFormat(loc, { style: 'currency', currency }).format(price);
+  // const loc = region ? IANA_BY_REGION_MAP.get(Number(region))?.locale || 'en-US' : locale;
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(price);
 }
 
 /**

--- a/_src/scripts/utils/utils.js
+++ b/_src/scripts/utils/utils.js
@@ -347,7 +347,7 @@ export function setDataOnBuyLinks(element, dataInfo) {
   if (variation.variation_name) element.dataset.variation = variation.variation_name;
 }
 
-export function formatPrice(price, currency, region = null, locale = null) {
+export function formatPrice(price, currency) {
   if (!price) {
     return null;
   }


### PR DESCRIPTION
formating prices will always use 'en-US'

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/zh-hk/
- After: https://<branch>--www-websites--bitdefender.hlx.page/zh-hk/
