### PR TITLE
add an exception rule so await loader is put on the free page

### DIFF
--- a/_src/blocks/hero/hero.js
+++ b/_src/blocks/hero/hero.js
@@ -131,4 +131,10 @@ export default function decorate(block) {
     block.setAttribute('data-store-department', 'consumer');
     block.setAttribute('data-store-option', variant);
   }
+
+  // Add the await-loader class to the button that leads to the thank you page, this is an exception
+  // for the free antivirus page
+  if (block.querySelector('.button-container a[href*="/consumer/thank-you"]')) {
+    block.querySelector('.button-container a[href*="/consumer/thank-you"]').classList.add('await-loader');
+  }
 }

--- a/_src/styles/styles.css
+++ b/_src/styles/styles.css
@@ -1587,7 +1587,8 @@ main .section.blue a.button.modal::after {
   opacity: 0.4;
   cursor: default;
   min-height: 2rem;
-}
+  pointer-events: none;
+} 
 
 .await-loader * {
   visibility: hidden;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/drafts/matei-test
- After: https://add-spinner-on-free-page--www-websites--bitdefender.hlx.page/drafts/matei-test
