### PR TITLE
Refactor image paths to be absolute in non-production environments

### DIFF
--- a/_src/blocks/header/header.js
+++ b/_src/blocks/header/header.js
@@ -414,7 +414,7 @@ async function runDefaultHeaderLogic(block) {
 
       const aemHeaderHostname = window.location.hostname.includes('.hlx.')
         || window.location.hostname.includes('localhost')
-        ? 'https://www.bitdefender.com'
+        ? 'https://stage.bitdefender.com'
         : '';
 
       const aemHeaderFetch = await fetch(`${aemHeaderHostname}/content/experience-fragments/bitdefender/language_master/${aemFetchDomain}/header-navigation/mega-menu/master/jcr:content/root.html`);
@@ -431,7 +431,7 @@ async function runDefaultHeaderLogic(block) {
       contentDiv.innerHTML = aemHeaderHtml;
 
       // make image paths absolute for non-production environments
-      if (aemHeaderHostname === 'https://www.bitdefender.com') {
+      if (aemHeaderHostname === 'https://stage.bitdefender.com') {
         makeImagePathsAbsolute(contentDiv, aemHeaderHostname);
       }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/drafts/matei-test
- After: https://show-header-on-stage--www-websites--bitdefender.hlx.page/drafts/matei-test
