### PR TITLE
changed the exit popup to use the Franklin Store, not the AEM store

### DIFF
--- a/_src/blocks/exit-popup/exit-popup.js
+++ b/_src/blocks/exit-popup/exit-popup.js
@@ -1,4 +1,4 @@
-import { ProductInfo } from '../../scripts/libs/store/store.js';
+import { ProductInfo, Store } from '../../scripts/libs/store/store.js';
 // eslint-disable-next-line no-unused-vars
 export default async function decorate(block) {
   const parentSelector = block.closest('.section');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/drafts/matei-test
- After: https://fix-non-loading-prices-issue-TS-AV--www-websites--bitdefender.hlx.page/drafts/matei-test
