### PR TITLE
fix: log parsed user geolocation response in getProductVariations method

### DIFF
--- a/_src/scripts/libs/store/store.js
+++ b/_src/scripts/libs/store/store.js
@@ -926,7 +926,7 @@ class Vlaicu {
 	static async getProductVariations(productId, campaign) {
 		const userCountry = await User.country;
 		const userGeoIp = await fetch(`${Constants.DEV_BASE_URL}/p-api/v1/countries/${userCountry.toUpperCase()}/locales`);
-		console.log(userGeoIp);
+		console.log(userGeoIp.json());
 		const pathVariablesResolverObject = {
 			"{locale}": Page.locale,
 			"{bundleId}": productId,


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/zh-hk/
- After: https://<branch>--www-websites--bitdefender.hlx.page/zh-hk/
