### PR TITLE
Adding secpass + secpassm to the mapping for Zuora

### DIFF
--- a/_src/scripts/libs/store/store.js
+++ b/_src/scripts/libs/store/store.js
@@ -494,7 +494,7 @@ export class Product {
 		if (windowURL.searchParams.has("channel")) {
 			zuoraCart.searchParams.set("channel", windowURL.searchParams.get("channel"));
 		}
-		console.log('this ', this)
+
 		zuoraCart.searchParams.set("product_id", this.productId);
 		zuoraCart.searchParams.set("payment_period", monthlyProducts[this.id] ? `${devices}d1m` : `${devices}d${years}y`);
 		zuoraCart.searchParams.set("country", "NL");
@@ -756,7 +756,7 @@ export class Product {
 
 class BitCheckout {
 
-	static monthlyProducts = ["psm", "pspm", "vpn-monthly", "passm", "pass_spm", "dipm", "us_i_m",
+	static monthlyProducts = ["psm", "pspm", "vpn-monthly", "passm", "pass_spm", "secpassm", "dipm", "us_i_m",
 		"us_f_m", "us_pf_m", "us_pi_m", "us_pie_m", "us_pfe_m"]
 
 	// this products come with device_no set differently from the init-selector api where they are set to 1

--- a/_src/scripts/libs/store/store.js
+++ b/_src/scripts/libs/store/store.js
@@ -494,6 +494,7 @@ export class Product {
 		if (windowURL.searchParams.has("channel")) {
 			zuoraCart.searchParams.set("channel", windowURL.searchParams.get("channel"));
 		}
+		console.log('this ', this)
 		zuoraCart.searchParams.set("product_id", this.productId);
 		zuoraCart.searchParams.set("payment_period", monthlyProducts[this.id] ? `${devices}d1m` : `${devices}d${years}y`);
 		zuoraCart.searchParams.set("country", "NL");
@@ -778,6 +779,8 @@ class BitCheckout {
 		passm: "com.bitdefender.passwordmanager",
 		pass_sp: "com.bitdefender.passwordmanager",
 		pass_spm: "com.bitdefender.passwordmanager",
+		secpass: 'com.bitdefender.securepass',
+    	secpassm: 'com.bitdefender.securepass',
 		bms: "com.bitdefender.bms",
 		mobile: "com.bitdefender.bms",
 		ios: "com.bitdefender.iosprotection",
@@ -808,7 +811,7 @@ class BitCheckout {
 		pass: "Bitdefender Password Manager",
 		pass_sp: "Bitdefender Password Manager Shared Plan",
 		passm: "Bitdefender Password Manager",
-		pass_spm: "Bitdefender Password Manager Shared Plan"
+		pass_spm: "Bitdefender Password Manager Shared Plan",
 	}
 
 	static getKey() {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.hlx.page/drafts/lucia-test/
- After: https://fix-zuora-pid--www-websites--bitdefender.hlx.page/drafts/lucia-test/