### PR TITLE
fixed a/b test data layer inconsistency on free-antivirus page

### DIFF
--- a/_src/scripts/libs/data-layer.js
+++ b/_src/scripts/libs/data-layer.js
@@ -826,7 +826,7 @@ const checkClickEventAfterRedirect = () => {
  * Add entry for free products
  */
 const getFreeProductsEvents = () => {
-  const currentPage = window.location.href.split('/').filter(Boolean).pop();
+  const currentPage = Page.name;
   if (currentPage === 'free-antivirus') {
     // on Free Antivirus page we should add Free Antivirus as the main product
     AdobeDataLayerService.push(new MainProductLoadedEvent({


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](https://github.com/bitdefender/www-websites/issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:

Before: https://main--www-websites--bitdefender.hlx.page/drafts/lucia-test/
After: https://dex-19400--www-websites--bitdefender.hlx.page/drafts/lucia-test/
