### PR TITLE
fix: update icon URL for new product boxes

### DIFF
--- a/_src/blocks/new-prod-boxes/new-prod-boxes.css
+++ b/_src/blocks/new-prod-boxes/new-prod-boxes.css
@@ -397,7 +397,7 @@
   line-height: 17px;
   margin-bottom: 8px;
   list-style-type: none;
-  background: url("https://bitdefender.com/icons/circle-check-sharp-solid.svg") top 2px left no-repeat transparent;
+  background: url("https://bitdefender.com/common/icons/circle-check-sharp-solid.svg") top 2px left no-repeat transparent;
   padding-left: 22px;
   background-size: 13px;
   position: relative;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.aem.page/drafts/matei-test/
- After: https://fix-icon-path--www-websites--bitdefender.aem.page/drafts/matei-test/
