### PR TITLE
feat(mbox-canvas): add tracking ID metadata handling in page load event

### DIFF
--- a/_src/blocks/mbox-canvas/mbox-canvas.js
+++ b/_src/blocks/mbox-canvas/mbox-canvas.js
@@ -4,7 +4,7 @@ import {
   Target,
 } from '../../scripts/libs/data-layer.js';
 import { decorateMain, detectModalButtons } from '../../scripts/scripts.js';
-import { loadBlocks } from '../../scripts/lib-franklin.js';
+import { getMetadata, loadBlocks } from '../../scripts/lib-franklin.js';
 
 function decorateHTMLOffer(aemHeaderHtml) {
   const newHtml = document.createElement('div');
@@ -41,6 +41,7 @@ function createOfferParameters() {
  * @returns {Promise<void>} - A promise that resolves when the event is updated and pushed.
  */
 async function updatePageLoadStartedEvent(offer, mboxName) {
+  const urlParams = new URLSearchParams(window.location.search);
   const match = offer[mboxName].content.offer.match(/\/([^/]+)\.plain\.html$/);
   const result = match ? match[1] : null;
   const newObject = await new PageLoadStartedEvent();
@@ -51,6 +52,10 @@ async function updatePageLoadStartedEvent(offer, mboxName) {
       newObject.page.info[key] = result;
     }
   });
+  let trackingID = getMetadata('cid');
+  trackingID = trackingID.replace('<language>', urlParams.get('lang'));
+  trackingID = trackingID.replace('<asset name>', urlParams.get('feature'));
+  newObject.page.attributes.trackingID = trackingID;
   AdobeDataLayerService.push(newObject);
 }
 

--- a/_src/blocks/mbox-canvas/mbox-canvas.js
+++ b/_src/blocks/mbox-canvas/mbox-canvas.js
@@ -56,6 +56,8 @@ async function updatePageLoadStartedEvent(offer, mboxName) {
   trackingID = trackingID.replace('<language>', urlParams.get('lang'));
   trackingID = trackingID.replace('<asset name>', urlParams.get('feature'));
   newObject.page.attributes.trackingID = trackingID;
+
+  newObject.page.info.language = urlParams.get('lang') || 'en-us';
   AdobeDataLayerService.push(newObject);
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.aem.page/drafts/matei-test
- After: https://webview-tracking-id--www-websites--bitdefender.aem.page/drafts/matei-test
