### PR TITLE
DEX-22855 fix: elements alignment for money-back component

### DIFF
--- a/_src/blocks/money-back/money-back.css
+++ b/_src/blocks/money-back/money-back.css
@@ -74,13 +74,17 @@
   }
 
 .money-back > ul > li {
-    display: inline-block;
+    display: inline-flex;
     padding: 8px;
     margin: 0 37px;
     text-align: center;
     width: 268px;
     vertical-align: top;
     font: normal normal normal 14px/16px var(--body-font-family);
+  }
+
+  .money-back > ul > li > div{
+    min-height: 100%;
   }
 
   .creator-money-back .money-back > ul > li {
@@ -129,9 +133,9 @@
   }
 
   .money-back > ul > li strong {
-    display: inline-block;
     font: normal normal bold 18px/16px var(--body-font-family);
     padding-bottom: 11px;
+    display: inline-flex;
   }
 
   .money-back .default-content-wrapper {

--- a/_src/blocks/money-back/money-back.js
+++ b/_src/blocks/money-back/money-back.js
@@ -1,4 +1,5 @@
 import { decorateIcons } from '../../scripts/lib-franklin.js';
+import { matchHeights } from '../../scripts/utils/utils.js';
 
 export default function decorate(block, options) {
   if (options) {
@@ -24,4 +25,7 @@ export default function decorate(block, options) {
   });
 
   decorateIcons(block);
+  matchHeights(block, 'h4');
+  matchHeights(block, 'p:first-of-type');
+  matchHeights(block, 'p:nth-of-type(2)');
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--www-websites--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-22855--www-websites--bitdefender.aem.page/drafts/test-page/
