### PR TITLE
DEX-24442 | fix: prevent cross-component nanoblocks from blocking access to metadata

### DIFF
--- a/_src/blocks/columns/columns.js
+++ b/_src/blocks/columns/columns.js
@@ -215,7 +215,7 @@ export default function decorate(block) {
     leftCol.innerHTML = `<video data-type="dam" data-video="" src="${videoPath}" disableremoteplayback="" playsinline="" controls="" poster="${videoImg}"></video>`;
   }
 
-  renderNanoBlocks(block);
+  renderNanoBlocks(block.closest('.section'), undefined, undefined, block);
 
   const chatOptions = document.querySelector('.chat-options');
   if (chatOptions) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-24442--www-websites--bitdefender.aem.page/drafts/test-page/
