### PR TITLE
fix: adjust minimum width for award component images

### DIFF
--- a/_src/blocks/awards/awards.css
+++ b/_src/blocks/awards/awards.css
@@ -103,7 +103,7 @@
 .awards-component > div:nth-child(3) div img {
   height: 100px;
   max-width: 100%;
-  min-width: 40px;
+  min-width: 30px;
   width: auto;
   object-fit: contain;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-websites--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-26517--www-websites--bitdefender.aem.page/drafts/test-page/
DEX-26517