### PR TITLE
Add dark mode support to webview plan selector

### DIFF
--- a/_src/blocks/webview-plan-selector/webview-plan-selector.css
+++ b/_src/blocks/webview-plan-selector/webview-plan-selector.css
@@ -348,6 +348,68 @@
     text-decoration: none;
 }
 
+.webview-plan-selector.dark-mode {
+    color: #e8ecf3;
+    background: #141517;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-layout > h1,
+.webview-plan-selector.dark-mode .webview-plan-selector-layout > h2,
+.webview-plan-selector.dark-mode .webview-plan-selector-layout > h3,
+.webview-plan-selector.dark-mode .webview-plan-selector-feature-list li,
+.webview-plan-selector.dark-mode .webview-plan-selector-trust-list li,
+.webview-plan-selector.dark-mode .webview-plan-selector-plan-copy h2,
+.webview-plan-selector.dark-mode .webview-plan-selector-plan-copy h3,
+.webview-plan-selector.dark-mode .webview-plan-selector-plan-price strong,
+.webview-plan-selector.dark-mode .webview-plan-selector-plan-price > span,
+.webview-plan-selector.dark-mode .webview-plan-selector-legal {
+    color: #e8ecf3;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-trust-list li .icon {
+    color: #9fb0c4;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-plan {
+    border-color: #2b3646;
+    background: #111923;
+    box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-plan.is-selected {
+    border-color: #3a8fff;
+    background: #162439;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-plan:focus-visible {
+    outline-color: #67a8ff;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-plan .webview-plan-selector-radio {
+    border-color: #141517;
+    box-shadow: 0 0 0 1px #5f7289;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-plan.is-selected .webview-plan-selector-radio {
+    border-color: #141517;
+    background: #4ea0ff;
+    box-shadow: 0 0 0 1px #4ea0ff;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-plan-copy p:not(.webview-plan-selector-billed),
+.webview-plan-selector.dark-mode .webview-plan-selector-plan-copy .webview-plan-selector-billed {
+    color: rgb(232 236 243 / 80%);
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-cta .button {
+    border-color: #3a8fff;
+    background-color: #3a8fff;
+}
+
+.webview-plan-selector.dark-mode .webview-plan-selector-legal a {
+    color: #84bdff;
+}
+
 @media (max-width: 767px) {
     .webview-plan-selector .webview-plan-selector-layout > h1,
     .webview-plan-selector .webview-plan-selector-layout > h2,

--- a/_src/blocks/webview-plan-selector/webview-plan-selector.js
+++ b/_src/blocks/webview-plan-selector/webview-plan-selector.js
@@ -382,5 +382,10 @@ export default async function decorate(block) {
     selectPlan(selectedIndex);
   }
 
+  const url = new URL(window.location.href);
+  if (url.searchParams.has('theme') && url.searchParams.get('theme') === 'dark') {
+    block.classList.add('dark-mode');
+  }
+
   await checkAndReplacePrivacyPolicyLink(block);
 }


### PR DESCRIPTION
## Summary
Add a dark mode variant for the webview plan selector block, activated via the `dark-mode` class on the block.

## Changes
- Add scoped dark mode styles for selector layout, cards, text, radio states, CTA button, and legal link colors.
- Keep the implementation isolated to the webview plan selector block styles and behavior.

## Notes
- Source repo/branch: `bitdefender/www-websites:DEX-26858`
- Target branch: `stage`DEX-26858