### PR TITLE
feat: webview discount modal and mbox auto-renewal support

### DIFF
--- a/_src/blocks/mbox-canvas/mbox-canvas.js
+++ b/_src/blocks/mbox-canvas/mbox-canvas.js
@@ -63,6 +63,7 @@ async function createOfferParameters() {
   const feature = urlParams.get('feature');
   const language = urlParams.get('lang');
   const serviceId = urlParams.get('service_id');
+  const autoRenewal = urlParams.get('auto_renewal');
 
   if (feature) {
     parameters.feature = feature.replaceAll('_', '-');
@@ -78,6 +79,10 @@ async function createOfferParameters() {
       // search for segment in the url params
       parameters.segment = serviceIdSegment;
     }
+  }
+
+  if (autoRenewal) {
+    parameters.auto_renewal = autoRenewal;
   }
 
   return parameters;


### PR DESCRIPTION
## Summary
- add discount modal behavior and supporting background asset for the `webview` block
- add auto-renewal parameter handling when creating offers in `mbox-canvas`
- include associated webview unit test coverage updates for the new modal behavior

## Test plan
- [ ] Run `npm test -- _src/tests/blocks/webview/webview.test.js`
- [ ] Validate `webview` behavior in local stage preview
- [ ] Validate `mbox-canvas` offer payload includes auto-renewal parameter

Made with [Cursor](https://cursor.com)DEX-27250